### PR TITLE
truncateString func now accounts for missing codeblock backticks

### DIFF
--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -5,6 +5,8 @@ import {
     stripHeader,
     stripJsxRef,
     convertEmojiTags,
+    truncateString,
+    getSection
 } from '../parser/index.js';
 import fs from 'fs';
 import mapHeader from './__fixtures__/map.header.json';
@@ -12,8 +14,10 @@ import titleDescription from './__fixtures__/title.description.json';
 import spliceDescription from './__fixtures__/splice.description.json';
 
 const JS_FILE_PATH = './lib/javascript/global_objects/array/map/index.md';
+const JS_STR_SUBSTR_PATH = './lib/javascript/global_objects/string/substring/index.md';
 const HTML_FILE_PATH = './lib/html/global_attributes/title/index.md';
 let jsFile: string;
+let substrFile: string;
 let htmlFile: string;
 
 describe('parser', () => {
@@ -21,6 +25,7 @@ describe('parser', () => {
         try {
             jsFile = fs.readFileSync(JS_FILE_PATH).toString();
             htmlFile = fs.readFileSync(HTML_FILE_PATH).toString();
+            substrFile = fs.readFileSync(JS_STR_SUBSTR_PATH).toString();
         } catch (error) {
             throw new Error('Error reading file: ' + error);
         }
@@ -85,4 +90,13 @@ describe('parser', () => {
             expect(convertEmojiTags('[!WARN]')).toBe('[!WARN]');
         });
     });
+
+    describe('truncateString', () => {
+        it('cuts a string down to the provided length and corrects missing codeblock backticks if needed', () => {
+            const section = getSection("Example", substrFile);
+            const truncatedStr = truncateString(section, 1024);
+            expect(truncatedStr).toHaveLength(1024);
+        })
+    })
+
 });

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -164,13 +164,23 @@ const removeTitle = (document: string) => {
 };
 
 /**
- * Cuts a string down to the specified length if needed
+ * Cuts a string down to the provided length and corrects missing codeblock backticks if needed
  * Appends '...' if the string was trimmed
+ * Appends '...```' if the codeblock backticks were corrected
  * @param {string} document
  * @param {number} length
  */
 const truncateString = (document: string, length: number) => {
-    return document.length > length ? document.slice(0, length - 3) + '...' : document;
+    // Returns original document if its length is smaller than the discord maximum length
+    if (length > document.length) return document;
+    // Prepare document for truncate, appending ellipsis
+    const truncatedStr = document.slice(0, length - 3) + '...';
+    // Splits truncated string on \n and \r characters 
+    let lines = truncatedStr.match(/[^\r\n]+/g);
+    // Filter lines for codeblock backticks, store array length
+    let backtickMatches = lines?.filter(item => item.startsWith('```')).length;
+    // If the number of backtick instances is odd, returns document with an additional 3 backticks alongside the ellipsis. Else, return original truncated string
+    if (backtickMatches) return backtickMatches % 2 !== 0 ? document.slice(0, length - 7) + '...\n```' : truncatedStr;
 };
 
 /**


### PR DESCRIPTION
### Issue

Due to Discord's character limit, truncating .md strings sometimes resulted in a truncation after an opening codeblock backticks, resulting in an incomplete codeblock.

### Solution

truncateString now appends closing backticks in instances of incomplete codeblocks. Otherwise, it returns the document with appended ellipses, or the original document if a truncation isn't needed.

